### PR TITLE
added mdns responder and MDNSWebServer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,16 @@ An Unicast blocking function is added to set and get the flag in a UDP socket.
 
 ## MDNS Responder 
 
-A MDNS responder can listen and respond to MDNS name requests, for example to have a 
-be accessible on the MDNS name "webserver3.local":
+The MDNS responder can listen and respond to MDNS name requests, for example a 
+webserver can be accessible via the MDNS name "webserver3.local".
 
 ***example***
 
 	char mdnsName[] = "webserver3"; 
 	EthernetMDNSResponder mdnsResponder;
 
-Setup the MDNS responder to listen to the configured name.
+Setup the MDNS responder to listen to the configured name (.local will be 
+appended).
 
 ***example***
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,30 @@ An Unicast blocking function is added to set and get the flag in a UDP socket.
 	
 	udp.setUnicastBlock(false);
 	udp.setUnicastBlock();
+
+## MDNS Responder 
+
+A MDNS responder can listen and respond to MDNS name requests, for example to have a 
+be accessible on the MDNS name "webserver3.local":
+
+***example***
+
+	char mdnsName[] = "webserver3"; 
+	EthernetMDNSResponder mdnsResponder;
+
+Setup the MDNS responder to listen to the configured name.
+
+***example***
+
+	mdnsResponder.begin(mdnsName)
+
+Call the update() function on the MDNS responder every loop iteration to
+make sure it can detect and respond to name requests.
+  
+***example***
+
+	mdnsResponder.poll();
+
 	
 ## PHY support
 

--- a/examples/MDNSWebServer/MDNSWebServer.ino
+++ b/examples/MDNSWebServer/MDNSWebServer.ino
@@ -1,0 +1,139 @@
+/*
+ MDNS Web Server  (based on WiFiMDNSWebServer)
+
+ A simple web server that shows the value of the analog input pins,
+ and exposes itself on the MDNS name 'webserver3.local'.
+
+ On Linux (like Ubuntu 15.04) or OSX you can access the web page
+ on the device in a browser at 'http://webserver3.local/'.
+
+ On Windows you'll first need to install the Bonjour Printer Services
+ from:
+   https://support.apple.com/kb/dl999?locale=en_US
+ Then you can access the device in a browser at 'http://ethernet3.local/'.
+
+
+ Circuit:
+ * Ethernet Shield2 (with WIZnet5500)
+ * Analog inputs attached to pins A0 through A5 (optional)
+
+ created 13 July 2010
+ by dlf (Metodo2 srl)
+ modified 31 May 2012
+ by Tom Igoe
+ modified 27 January 2016
+ by Tony DiCola
+ modified 06 August 2017
+ by Michael Blank
+
+*/
+
+#include <SPI.h>
+#include <Ethernet3.h>
+#include <EthernetMDNSResponder.h>
+
+byte mac[] = {
+  0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED
+};
+//IPAddress ip(192, 168, 1, 177);
+
+char mdnsName[] = "webserver3"; // the MDNS name that the board will respond to
+// Note that the actual MDNS name will have '.local' after
+// the name above, so "webserver3" will be accessible on
+// the MDNS name "webserver3.local".
+
+// Create a MDNS responder to listen and respond to MDNS name requests.
+EthernetMDNSResponder mdnsResponder;
+
+
+EthernetServer server(80);
+
+void setup() {
+  //Initialize serial and wait for port to open:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for native USB port only
+  }
+  
+  Ethernet.begin(mac);   // use DHCP
+  server.begin();
+
+  // print your shield's IP address:
+  IPAddress ip = Ethernet.localIP();
+  Serial.print("IP Address: ");
+  Serial.println(ip);
+
+  // Setup the MDNS responder to listen to the configured name.
+
+  if (!mdnsResponder.begin(mdnsName)) {
+    Serial.println("Failed to start MDNS responder!");
+    while(1);
+  }
+
+  
+
+  Serial.print("Server listening at http://");
+  Serial.print(mdnsName);
+  Serial.println(".local/");
+}
+
+
+void loop() {
+  // Call the update() function on the MDNS responder every loop iteration to
+  // make sure it can detect and respond to name requests.
+  mdnsResponder.poll();
+
+  // listen for incoming clients
+  EthernetClient client = server.available();
+  if (client) {
+    Serial.println("new client");
+    // an http request ends with a blank line
+    boolean currentLineIsBlank = true;
+    while (client.connected()) {
+      if (client.available()) {
+        char c = client.read();
+        Serial.write(c);
+        // if you've gotten to the end of the line (received a newline
+        // character) and the line is blank, the http request has ended,
+        // so you can send a reply
+        if (c == '\n' && currentLineIsBlank) {
+          // send a standard http response header
+          client.println("HTTP/1.1 200 OK");
+          client.println("Content-Type: text/html");
+          client.println("Connection: close");  // the connection will be closed after completion of the response
+          client.println("Refresh: 5");  // refresh the page automatically every 5 sec
+          client.println();
+          client.println("<!DOCTYPE HTML>");
+          client.println("<html>");
+          // output the value of each analog input pin
+          for (int analogChannel = 0; analogChannel < 6; analogChannel++) {
+            int sensorReading = analogRead(analogChannel);
+            client.print("analog input ");
+            client.print(analogChannel);
+            client.print(" is ");
+            client.print(sensorReading);
+            client.println("<br />");
+          }
+          client.println("</html>");
+          break;
+        }
+        if (c == '\n') {
+          // you're starting a new line
+          currentLineIsBlank = true;
+        }
+        else if (c != '\r') {
+          // you've gotten a character on the current line
+          currentLineIsBlank = false;
+        }
+      }
+    }
+    // give the web browser time to receive the data
+    delay(1);
+
+    // close the connection:
+    client.stop();
+    Serial.println("client disconnected");
+  }
+}
+
+

--- a/keywords.txt
+++ b/keywords.txt
@@ -11,6 +11,7 @@ EthernetClient	KEYWORD1
 EthernetServer	KEYWORD1
 IPAddress	KEYWORD1
 EthernetUdp3	KEYWORD1
+EthernetMDNSResponder	KEYWORD1
 DNS	KEYWORD1
 DCHP	KEYWORD1
 Twitter	KEYWORD1
@@ -27,6 +28,7 @@ read	KEYWORD2
 peek	KEYWORD2
 flush	KEYWORD2
 stop	KEYWORD2
+poll	KEYWORD2
 connected	KEYWORD2
 begin	KEYWORD2
 beginMulticast	KEYWORD2

--- a/src/EthernetMDNSResponder.cpp
+++ b/src/EthernetMDNSResponder.cpp
@@ -1,0 +1,221 @@
+// Port of  WINC1500 MDNS Responder to WIZnet5500.
+// Author: Tony DiCola
+//         Michael Blank
+// This MDNSResponder class implements just enough MDNS functionality to respond
+// to name requests, for example 'foo.local'.  This does not implement any other
+// MDNS or Bonjour functionality like services, etc.
+//
+// Copyright (c) 2016 Adafruit Industries.  All right reserved.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include <avr/pgmspace.h>
+#ifndef ARDUINO_ARCH_AVR
+#include <strings.h>
+#endif
+
+#include "Arduino.h"
+#include "EthernetMDNSResponder.h"
+#include "utility/util.h"
+
+// Important RFC's for reference:
+// - DNS request and response: http://www.ietf.org/rfc/rfc1035.txt
+// - Multicast DNS: http://www.ietf.org/rfc/rfc6762.txt
+
+#define HEADER_SIZE 12
+#define TTL_OFFSET 4
+#define IP_OFFSET 10
+
+const uint8_t expectedRequestHeader[HEADER_SIZE] PROGMEM = {
+  0x00, 0x00,
+  0x00, 0x00,
+  0x00, 0x01, // questions (these 2 bytes are ignored)
+  0x00, 0x00,
+  0x00, 0x00,
+  0x00, 0x00
+};
+
+const uint8_t responseHeader[] PROGMEM = {
+  0x00, 0x00,   // ID = 0
+  0x84, 0x00,   // Flags = response + authoritative answer
+  0x00, 0x00,   // Question count = 0
+  0x00, 0x01,   // Answer count = 1
+  0x00, 0x00,   // Name server records = 0
+  0x00, 0x01    // Additional records = 1
+};
+
+// Generate positive response for IPV4 address
+const uint8_t aRecord[] PROGMEM = {
+  0x00, 0x01,                // Type = 1, A record/IPV4 address
+  0x80, 0x01,                // Class = Internet, with cache flush bit
+  0x00, 0x00, 0x00, 0x00,    // TTL in seconds, to be filled in later
+  0x00, 0x04,                // Length of record
+  0x00, 0x00, 0x00, 0x00     // IP address, to be filled in later
+};
+
+// Generate negative response for IPV6 address (CC3000 doesn't support IPV6)
+const uint8_t nsecRecord[] PROGMEM = { 
+  0xC0, 0x0C,                // Name offset
+  0x00, 0x2F,                // Type = 47, NSEC (overloaded by MDNS)
+  0x80, 0x01,                // Class = Internet, with cache flush bit
+  0x00, 0x00, 0x00, 0x00,    // TTL in seconds, to be filled in later
+  0x00, 0x08,                // Length of record
+  0xC0, 0x0C,                // Next domain = offset to FQDN
+  0x00,                      // Block number = 0
+  0x04,                      // Length of bitmap = 4 bytes
+  0x40, 0x00, 0x00, 0x00     // Bitmap value = Only first bit (A record/IPV4) is set
+};
+
+const uint8_t domain[] PROGMEM = { 'l', 'o', 'c', 'a', 'l' };
+
+EthernetMDNSResponder::EthernetMDNSResponder() :
+  minimumExpectedRequestLength(0)
+{
+}
+
+EthernetMDNSResponder::~EthernetMDNSResponder()
+{
+}
+
+bool EthernetMDNSResponder::begin(const char* _name, uint32_t _ttlSeconds)
+{
+  int nameLength = strlen(_name);
+
+  if (nameLength > 255) {
+    // Can only handle domains that are upto 255 chars in length.
+    minimumExpectedRequestLength = 0;
+    return false;
+  }
+
+  name = _name;
+  ttlSeconds = _ttlSeconds;
+
+  name.toLowerCase();
+  minimumExpectedRequestLength = HEADER_SIZE + 1 + nameLength + 1 + sizeof(domain) + 5;
+
+  // Open the MDNS UDP listening socket on port 5353 with multicast address
+  // 224.0.0.251 (0xE00000FB)
+  if (!udpSocket.beginMulticast(IPAddress(224, 0, 0, 251), 5353)) {
+    return false;
+  }
+
+  return true;
+}
+
+void EthernetMDNSResponder::poll()
+{
+  if (parseRequest()) {
+    replyToRequest();
+  }
+}
+
+bool EthernetMDNSResponder::parseRequest()
+{
+  int packetLength = udpSocket.parsePacket();
+
+  if (packetLength) {
+    // check if parsed packet matches expected request length
+    if (packetLength < minimumExpectedRequestLength) {
+      // it does not, read the full packet in and drop data
+      while(udpSocket.available()) {
+        udpSocket.read();
+      }
+
+      return false;
+    }
+
+    // read up to the min expect request length
+    uint8_t request[minimumExpectedRequestLength];
+    udpSocket.read(request, minimumExpectedRequestLength);
+
+    // discard the rest
+    while(udpSocket.available()) {
+      udpSocket.read();
+    }
+
+    // parse request
+    uint8_t requestNameLength   = request[HEADER_SIZE];
+    uint8_t* requestName        = &request[HEADER_SIZE + 1];
+    uint8_t requestDomainLength = request[HEADER_SIZE + 1 + requestNameLength];
+    uint8_t* requestDomain      = &request[HEADER_SIZE + 1 + requestNameLength + 1];
+    uint16_t requestQtype;
+    uint16_t requestQclass;
+
+    memcpy(&requestQtype, &request[minimumExpectedRequestLength - 4], sizeof(requestQtype));
+    memcpy(&requestQclass, &request[minimumExpectedRequestLength - 2], sizeof(requestQclass));
+
+    requestQtype = ntohs(requestQtype);
+    requestQclass = ntohs(requestQclass);
+
+    // compare request
+    if (memcmp_P(request, expectedRequestHeader, 4) == 0 &&                      // request header start match
+        memcmp_P(&request[6], &expectedRequestHeader[6], 6) == 0 &&              // request header end match
+        requestNameLength == name.length() &&                                    // name length match
+        strncasecmp(name.c_str(), (char*)requestName, requestNameLength) == 0 && // name match
+        requestDomainLength == sizeof(domain) &&                                 // domain length match
+        memcmp_P(requestDomain, domain, requestDomainLength) == 0 &&             // suffix match
+        requestQtype == 0x0001 &&                                                // request QType match
+        requestQclass == 0x0001) {                                               // request QClass match
+
+      return true;
+    }
+  }
+
+  return false;
+}
+
+void EthernetMDNSResponder::replyToRequest()
+{
+  int nameLength = name.length();
+  int domainLength = sizeof(domain);
+  uint32_t ipAddress = Ethernet.localIP();
+  uint32_t ttl = htonl(ttlSeconds);
+
+  int responseSize = sizeof(responseHeader) + 1 + nameLength + 1 + domainLength + 1 + sizeof(aRecord) + sizeof(nsecRecord);
+  uint8_t response[responseSize];
+  uint8_t* r = response;
+
+  // copy header
+  memcpy_P(r, responseHeader, sizeof(responseHeader));
+  r += sizeof(responseHeader);
+  
+  // copy name
+  *r = nameLength;
+  memcpy(r + 1, name.c_str(), nameLength);
+  r += (1 + nameLength);
+
+  // copy domain
+  *r = domainLength;
+  memcpy_P(r + 1, domain, domainLength);
+  r += (1 + domainLength);
+
+  // terminator
+  *r = 0x00;
+  r++;
+
+  // copy A record
+  memcpy_P(r, aRecord, sizeof(aRecord));
+  memcpy(r + TTL_OFFSET, &ttl, sizeof(ttl));            // replace TTL value
+  memcpy(r + IP_OFFSET, &ipAddress, sizeof(ipAddress)); // replace IP address value
+  r += sizeof(aRecord);
+
+  // copy NSEC record
+  memcpy_P(r, nsecRecord, sizeof(nsecRecord));
+  r += sizeof(nsecRecord);
+
+  udpSocket.beginPacket(IPAddress(224, 0, 0, 251), 5353);
+  udpSocket.write(response, responseSize);
+  udpSocket.endPacket();
+}

--- a/src/EthernetMDNSResponder.h
+++ b/src/EthernetMDNSResponder.h
@@ -1,0 +1,52 @@
+// Port of  WINC1500 MDNS Responder to WIZnet5500.
+// Author: Tony DiCola
+//         Michael Blank
+// This MDNSResponder class implements just enough MDNS functionality to respond
+// to name requests, for example 'foo.local'.  This does not implement any other
+// MDNS or Bonjour functionality like services, etc.
+//
+// Copyright (c) 2016 Adafruit Industries.  All right reserved.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef ETHERNETMDNSRESPONDER_H
+#define ETHERNETMDNSRESPONDER_H
+
+#include "Ethernet3.h"
+#include "EthernetUdp3.h"
+#include "utility/util.h"
+
+class EthernetMDNSResponder {
+public:
+  EthernetMDNSResponder();
+  ~EthernetMDNSResponder();
+  bool begin(const char* _name, uint32_t _ttlSeconds = 3600);
+  void poll();
+
+private:
+  bool parseRequest();
+  void replyToRequest();
+
+private:
+  String name;
+  uint32_t ttlSeconds;
+
+  int minimumExpectedRequestLength;
+
+  // UDP socket for receiving/sending MDNS data.
+  EthernetUDP udpSocket;
+};
+
+#endif


### PR DESCRIPTION
I have added an MDNS responder (adapted from WiFi101 library) and an MDNS WebServer example - the webserver can be reached by its name 'http://webserver3.local' (Linux or OSX) - on Windows you'll first need to install the Bonjour Printer Services from:
   https://support.apple.com/kb/dl999?locale=en_US
 Then you can access the device in a browser at 'http://webserver3.local/'.
Remark: like in the WiFI101 lib, this is not a full MDNS implementation, just a "responder" (i.e. no service registration, discovery etc)
p.s.
this is my first pull request ever - I hope I've done it properly.