### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/Ethernet3.cpp
+++ b/src/Ethernet3.cpp
@@ -280,7 +280,7 @@ uint8_t EthernetClass::speed() {
     if(bitRead(w5500.getPHYCFGR(), 1) == 1) return 100;
     if(bitRead(w5500.getPHYCFGR(), 1) == 0) return 10;
     }
-  else return 0;
+   return 0;
   }
 
 const char* EthernetClass::speedReport() {
@@ -288,7 +288,7 @@ const char* EthernetClass::speedReport() {
     if(bitRead(w5500.getPHYCFGR(), 1) == 1) return "100 MB";
     if(bitRead(w5500.getPHYCFGR(), 1) == 0) return "10 MB";
     }
-  else return "NO LINK";
+   return "NO LINK";
   }
 
 uint8_t EthernetClass::duplex() {
@@ -296,7 +296,7 @@ uint8_t EthernetClass::duplex() {
     if(bitRead(w5500.getPHYCFGR(), 2) == 1) return 2;
     if(bitRead(w5500.getPHYCFGR(), 2) == 0) return 1;
     }
-  else return 0;
+   return 0;
   }
 
 const char* EthernetClass::duplexReport() {
@@ -304,7 +304,7 @@ const char* EthernetClass::duplexReport() {
     if(bitRead(w5500.getPHYCFGR(), 2) == 1) return "FULL DUPLEX";
     if(bitRead(w5500.getPHYCFGR(), 2) == 0) return "HALF DUPLEX";
     }
-  else return "NO LINK";
+   return "NO LINK";
   }
 
 void EthernetClass::setRtTimeOut(uint16_t timeout) {


### PR DESCRIPTION
Remove 'else' in various non-void functions that otherwise had branch paths
that could result in not reaching a return statement.

Issue noticed while using Arduino IDE 1.8.13.