### PR TITLE
Allow caller to provide DHCP instance to EthernetClass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.DS_Store
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-.DS_Store
+*.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
 .DS_Store
-.development
-**/no-export/**
-**/METADATA
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
-*.DS_Store
 .DS_Store
+.development
+**/no-export/**
+**/METADATA
+.vscode

--- a/src/Ethernet3.cpp
+++ b/src/Ethernet3.cpp
@@ -46,7 +46,9 @@ void EthernetClass::hardreset() {
 int EthernetClass::begin(void)
 {
   uint8_t mac_address[6] ={0,};
-  _dhcp = new DhcpClass();
+  if (_dhcp == nullptr) {
+    _dhcp = new DhcpClass();
+  }
 
   // Initialise the basic info
   w5500.init(_maxSockNum, _pinCS);
@@ -108,7 +110,9 @@ void EthernetClass::begin(IPAddress local_ip, IPAddress subnet, IPAddress gatewa
 #else
 int EthernetClass::begin(uint8_t *mac_address)
 {
-  _dhcp = new DhcpClass();
+  if (_dhcp == nullptr) {
+    _dhcp = new DhcpClass();
+  }
   // Initialise the basic info
   w5500.init(_maxSockNum, _pinCS);
   w5500.setMACAddress(mac_address);

--- a/src/Ethernet3.h
+++ b/src/Ethernet3.h
@@ -45,6 +45,10 @@ public:
   void setRstPin(uint8_t pinRST = 9); // for WIZ550io or USR-ES1, must set befor Ethernet.begin
   void setCsPin(uint8_t pinCS = 10); // must set befor Ethernet.begin
 
+  // Sets the DhcpClass instance to be used. Required if a local IP is not
+  // provided to begin.
+  void setDhcp(DhcpClass* dhcp) { _dhcp = dhcp; }
+
   // Initialize with less sockets but more RX/TX Buffer
   // maxSockNum = 1 Socket 0 -> RX/TX Buffer 16k
   // maxSockNum = 2 Socket 0, 1 -> RX/TX Buffer 8k


### PR DESCRIPTION
The existing code uses operator new to create a DHCP instance if EthernetClass::begin is called without specifying an IP address for the device. This PR adds a setDhcp method so that the caller can provide a statically allocated DHCP instance, thus avoiding all the issues that come with dynamically allocating memory on devices with as little as 2KB of RAM.
