### PR TITLE
Eliminated dependency on rand()

### DIFF
--- a/src/Dhcp.cpp
+++ b/src/Dhcp.cpp
@@ -36,11 +36,21 @@ void DhcpClass::reset_DHCP_lease(){
 int DhcpClass::request_DHCP_lease(){
     
     uint8_t messageType = 0;
-  
-    
-  
+      
+    //
+    // SKC: 21/05/2021
+    // Original Code was -
+    //    // Pick an initial transaction ID
+    //    _dhcpTransactionId = random(1UL, 2000UL);
+    // But consistently keeps crashing my code. And when not even being called! Just the existence of the
+    // call causes my code to be corrupted. Suspect there is an AVR chip bug causing memory corruption when 
+    // random() is included in a build. rand() routine also produces the same bug. 
+    // Have replaced with random code with that below which seems stable. As the random() was never seeded  
+    // by Ethernet3, it no worse a solution and avoids the random() or rand() calls.
+    //
+
     // Pick an initial transaction ID
-    _dhcpTransactionId = random(1UL, 2000UL);
+    _dhcpTransactionId = (micros() % 2000UL) + 1UL;
     _dhcpInitialTransactionId = _dhcpTransactionId;
 
     _dhcpUdpSocket.stop();


### PR DESCRIPTION
Hi

After programming a fairly big Arduino Mega 2560 app (55% flash) with Ethernet3 driving an Ethernet 2 Shield, I found my app was crashing when trying to initialize a STATIC connection after failing to initialize a DHCP connection. After more debugging I found my app was crashing without even your code being called. It was simply the existence of the code call that was causing the problem. So it must be some static aspect.

"Traced" through commenting/uncommenting chunks of code,  to your use of the random(). I don't think it is your code that is faulty but the underlying rand() function in the Arduino core. Specifically that supplied to ATMEL. I did not have the time to go that deep into the rand() library, so fixed the problem by removing your dependence on the rand() function. My app happens to not need it at all.

Hope by eliminating this dependence others find your library as reliable.

I admit, there may have been something else causing it, but I seriously dug into all parts of my code, and by eliminating rand() from your library, my application is very stable. 

There is a bunch of comments around my change which you might want to eliminate before merging.

Thanks for a great library.

SKC