### PR TITLE
Fixed memory leak on repeated calls to 'EthernetClass::begin' using dhcp

### DIFF
--- a/src/Ethernet3.cpp
+++ b/src/Ethernet3.cpp
@@ -46,7 +46,9 @@ void EthernetClass::hardreset() {
 int EthernetClass::begin(void)
 {
   uint8_t mac_address[6] ={0,};
-  _dhcp = new DhcpClass();
+  if (_dhcp == nullptr) {
+    _dhcp = new DhcpClass();
+  }
 
   // Initialise the basic info
   w5500.init(_maxSockNum, _pinCS);
@@ -108,7 +110,9 @@ void EthernetClass::begin(IPAddress local_ip, IPAddress subnet, IPAddress gatewa
 #else
 int EthernetClass::begin(uint8_t *mac_address)
 {
-  _dhcp = new DhcpClass();
+  if (_dhcp == nullptr) {
+    _dhcp = new DhcpClass();
+  }
   // Initialise the basic info
   w5500.init(_maxSockNum, _pinCS);
   w5500.setMACAddress(mac_address);


### PR DESCRIPTION
Existing code allocated a new DhcpClass() for every call to EthernetClass::begin when dhcp is being used.
This change adds a check to only allocate a new DhcpClass on the first call.