### PR TITLE
Change EthernetServer to derive from Print rather than Server

### DIFF
--- a/src/EthernetServer.h
+++ b/src/EthernetServer.h
@@ -6,7 +6,7 @@
 class EthernetClient;
 
 class EthernetServer : 
-public Server {
+public Print {
 private:
   uint16_t _port;
   void accept();


### PR DESCRIPTION
Change EthernetServer to derive from Print class rather than Server class to avoid compiler complaints that the begin(uint16_t) method is pure virtual.

This affects my projects targeting the ESP32. I haven't tested whether this issue exists when targeting other platforms, and I don't know if the derivation from Server is important in some use cases. Regardless, deriving from the Print class resolves the compilation errors for me, and hasn't presented any adverse effects in my use case.