### PR TITLE
Added function to specify SPI bus

### DIFF
--- a/src/Ethernet3.cpp
+++ b/src/Ethernet3.cpp
@@ -10,6 +10,7 @@
 
 #include "Ethernet3.h"
 #include "Dhcp.h"
+#include "Arduino.h"
 
 // XXX: don't make assumptions about the value of MAX_SOCK_NUM.
 uint8_t EthernetClass::_state[MAX_SOCK_NUM] = { 0, };
@@ -108,13 +109,13 @@ void EthernetClass::begin(IPAddress local_ip, IPAddress subnet, IPAddress gatewa
 }
 
 #else
-int EthernetClass::begin(uint8_t *mac_address)
+int EthernetClass::begin(uint8_t *mac_address, SPIClass *spi)
 {
   if (_dhcp == nullptr) {
     _dhcp = new DhcpClass();
   }
   // Initialise the basic info
-  w5500.init(_maxSockNum, _pinCS);
+  w5500.init(_maxSockNum, spi, _pinCS);
   w5500.setMACAddress(mac_address);
   w5500.setIPAddress(IPAddress(0,0,0,0).raw_address());
 
@@ -138,33 +139,33 @@ int EthernetClass::begin(uint8_t *mac_address)
   return ret;
 }
 
-void EthernetClass::begin(uint8_t *mac_address, IPAddress local_ip)
+void EthernetClass::begin(uint8_t *mac_address, IPAddress local_ip, SPIClass *spi)
 {
   IPAddress subnet(255, 255, 255, 0);
-  begin(mac_address, local_ip, subnet);
+  begin(mac_address, local_ip, subnet, spi);
 }
 
-void EthernetClass::begin(uint8_t *mac_address, IPAddress local_ip, IPAddress subnet)
+void EthernetClass::begin(uint8_t *mac_address, IPAddress local_ip, IPAddress subnet, SPIClass *spi)
 {
   // Assume the gateway will be the machine on the same network as the local IP
   // but with last octet being '1'
   IPAddress gateway = local_ip;
   gateway[3] = 1;
-  begin(mac_address, local_ip, subnet, gateway);
+  begin(mac_address, local_ip, subnet, gateway, spi);
 }
 
-void EthernetClass::begin(uint8_t *mac_address, IPAddress local_ip, IPAddress subnet, IPAddress gateway)
+void EthernetClass::begin(uint8_t *mac_address, IPAddress local_ip, IPAddress subnet, IPAddress gateway, SPIClass *spi)
 {
   // Assume the DNS server will be the machine on the same network as the local IP
   // but with last octet being '1'
   IPAddress dns_server = local_ip;
   dns_server[3] = 1;
-  begin(mac_address, local_ip, subnet, gateway, dns_server);
+  begin(mac_address, local_ip, subnet, gateway, dns_server, spi);
 }
 
-void EthernetClass::begin(uint8_t *mac, IPAddress local_ip, IPAddress subnet, IPAddress gateway, IPAddress dns_server)
+void EthernetClass::begin(uint8_t *mac, IPAddress local_ip, IPAddress subnet, IPAddress gateway, IPAddress dns_server, SPIClass *spi)
 {
-  w5500.init(_maxSockNum, _pinCS);
+  w5500.init(_maxSockNum, spi, _pinCS);
   w5500.setMACAddress(mac);
   w5500.setIPAddress(local_ip.raw_address());
   w5500.setGatewayIp(gateway.raw_address());

--- a/src/Ethernet3.h
+++ b/src/Ethernet3.h
@@ -71,11 +71,11 @@ public:
   // Initialize the Ethernet shield to use the provided MAC address and gain the rest of the
   // configuration through DHCP.
   // Returns 0 if the DHCP configuration failed, and 1 if it succeeded
-  int begin(uint8_t *mac_address);
-  void begin(uint8_t *mac_address, IPAddress local_ip);
-  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress subnet);
-  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress subnet, IPAddress gateway);
-  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress subnet, IPAddress gateway, IPAddress dns_server);
+  int begin(uint8_t *mac_address, SPIClass *spi = &SPI);
+  void begin(uint8_t *mac_address, IPAddress local_ip, SPIClass *spi = &SPI);
+  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress subnet, SPIClass *spi = &SPI);
+  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress subnet, IPAddress gateway, SPIClass *spi = &SPI);
+  void begin(uint8_t *mac_address, IPAddress local_ip, IPAddress subnet, IPAddress gateway, IPAddress dns_server, SPIClass *spi = &SPI);
 #endif
 
   int maintain();

--- a/src/utility/socket.cpp
+++ b/src/utility/socket.cpp
@@ -52,7 +52,7 @@ void close(SOCKET s)
  */
 uint8_t listen(SOCKET s)
 {
-  if (w5500.readSnSR(s) != SnSR::INIT)
+  if (w5500.readSnSR(s) != SnSR::INITL)
     return 0;
   w5500.execCmdSn(s, Sock_LISTEN);
   return 1;

--- a/src/utility/w5500.cpp
+++ b/src/utility/w5500.cpp
@@ -16,21 +16,23 @@
 #include "Arduino.h"
 
 #include "utility/w5500.h"
-
+static SPIClass* _spi;
 // W5500 controller instance
 W5500Class w5500;
 
 // SPI details
 SPISettings wiznet_SPI_settings(8000000, MSBFIRST, SPI_MODE0);
+
 uint8_t SPI_CS;
 
-void W5500Class::init(uint8_t socketNumbers, uint8_t ss_pin)
+void W5500Class::init(uint8_t socketNumbers, SPIClass *spi, uint8_t ss_pin)
 {
   SPI_CS = ss_pin;
-
+  _spi = spi;
   delay(1000);
   initSS();
-  SPI.begin();
+  _spi->begin();
+  
 
   if(socketNumbers == 1) {
     for (int i = 1; i < MAX_SOCK_NUM; i++) {
@@ -140,60 +142,61 @@ void W5500Class::read_data(SOCKET s, volatile uint16_t src, volatile uint8_t *ds
 
 uint8_t W5500Class::write(uint16_t _addr, uint8_t _cb, uint8_t _data)
 {
-    SPI.beginTransaction(wiznet_SPI_settings);
+    _spi->beginTransaction(wiznet_SPI_settings);
     setSS();
-    SPI.transfer(_addr >> 8);
-    SPI.transfer(_addr & 0xFF);
-    SPI.transfer(_cb);
-    SPI.transfer(_data);
+    _spi->transfer(_addr >> 8);
+    _spi->transfer(_addr & 0xFF);
+    _spi->transfer(_cb);
+    _spi->transfer(_data);
     resetSS();
-    SPI.endTransaction();
+    _spi->endTransaction();
 
     return 1;
 }
 
 uint16_t W5500Class::write(uint16_t _addr, uint8_t _cb, const uint8_t *_buf, uint16_t _len)
 {
-    SPI.beginTransaction(wiznet_SPI_settings);
+    _spi->beginTransaction(wiznet_SPI_settings);
     setSS();
-    SPI.transfer(_addr >> 8);
-    SPI.transfer(_addr & 0xFF);
-    SPI.transfer(_cb);
+    _spi->transfer(_addr >> 8);
+    _spi->transfer(_addr & 0xFF);
+    _spi->transfer(_cb);
     for (uint16_t i=0; i<_len; i++){
-        SPI.transfer(_buf[i]);
+        _spi->transfer(_buf[i]);
     }
     resetSS();
-    SPI.endTransaction();
+    _spi->endTransaction();
 
     return _len;
 }
 
 uint8_t W5500Class::read(uint16_t _addr, uint8_t _cb)
 {
-    SPI.beginTransaction(wiznet_SPI_settings);
+    _spi->beginTransaction(wiznet_SPI_settings);
     setSS();
-    SPI.transfer(_addr >> 8);
-    SPI.transfer(_addr & 0xFF);
-    SPI.transfer(_cb);
-    uint8_t _data = SPI.transfer(0);
+    _spi->transfer(_addr >> 8);
+    _spi->transfer(_addr & 0xFF);
+    _spi->transfer(_cb);
+    uint8_t _data = _spi->transfer(0);
     resetSS();
-    SPI.endTransaction();
+    _spi->endTransaction();
 
     return _data;
 }
 
 uint16_t W5500Class::read(uint16_t _addr, uint8_t _cb, uint8_t *_buf, uint16_t _len)
 {
-    SPI.beginTransaction(wiznet_SPI_settings);
+    _spi->beginTransaction(wiznet_SPI_settings);
     setSS();
-    SPI.transfer(_addr >> 8);
-    SPI.transfer(_addr & 0xFF);
-    SPI.transfer(_cb);
+    _spi->transfer(_addr >> 8);
+    _spi->transfer(_addr & 0xFF);
+    _spi->transfer(_cb);
     for (uint16_t i=0; i<_len; i++){
-        _buf[i] = SPI.transfer(0);
+        _buf[i] = _spi->transfer(0);
     }
     resetSS();
-    SPI.endTransaction();
+    _spi->endTransaction();
+
 
     return _len;
 }
@@ -209,14 +212,14 @@ void W5500Class::execCmdSn(SOCKET s, SockCMD _cmd) {
 
 uint8_t W5500Class::readVersion(void)
 {
-    SPI.beginTransaction(wiznet_SPI_settings);
+    _spi->beginTransaction(wiznet_SPI_settings);
     setSS();
-    SPI.transfer( 0x00 );
-    SPI.transfer( 0x39 );
-    SPI.transfer( 0x01);
-    uint8_t _data = SPI.transfer(0);
+    _spi->transfer( 0x00 );
+    _spi->transfer( 0x39 );
+    _spi->transfer( 0x01);
+    uint8_t _data = _spi->transfer(0);
     resetSS();
-    SPI.endTransaction();
+    _spi->endTransaction();
 
     return _data;
 }

--- a/src/utility/w5500.h
+++ b/src/utility/w5500.h
@@ -98,7 +98,7 @@ public:
 class SnSR {
 public:
   static const uint8_t CLOSED      = 0x00;
-  static const uint8_t INIT        = 0x13;
+  static const uint8_t INITL       = 0x13;
   static const uint8_t LISTEN      = 0x14;
   static const uint8_t SYNSENT     = 0x15;
   static const uint8_t SYNRECV     = 0x16;
@@ -131,7 +131,8 @@ public:
 class W5500Class {
 
 public:
-  void init(uint8_t socketNumbers, uint8_t ss_pin = 10);
+  
+  void init(uint8_t socketNumbers, SPIClass *spi, uint8_t ss_pin = 10);
   static uint8_t softReset(void);
   uint8_t readVersion(void);
 
@@ -345,6 +346,7 @@ private:
   static inline void setSS()   {  digitalWrite(SPI_CS, LOW); }
   static inline void resetSS() {  digitalWrite(SPI_CS, HIGH); }
 };
+
 
 extern W5500Class w5500;
 


### PR DESCRIPTION
Allows for an optional parameter to be passed to begin() to specify non-default SPI, similar to what is mentioned in #53.

Example usage:
- Ethernet.begin(mac, &customSpi);

Tested to work with NTP, DHCP examples and my own application.