### PR TITLE
Change maintainer to `sstaub`

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=Ethernet3
 version=1.5.6
 author=Arduino/sstaub
-maintainer=Arduino
+maintainer=sstaub
 sentence=Enables network connection (local and Internet) using the Arduino Ethernet board or shield. For all Arduino boards.
 paragraph=With this library you can use the Arduino Ethernet (shield or board) to connect to Internet. The library provides both Client and server functionalities. The library permits you to connect to a local network also with DHCP and to resolve DNS.
 category=Communication


### PR DESCRIPTION
Maintainer is changed from `Arduino` to `sstaub` within the `library.properties` file. 